### PR TITLE
humanize 4.14.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.12.2" %}
+{% set version = "4.14.0" %}
 {% set name = "humanize" %}
 
 package:
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: ce0715740e9caacc982bb89098182cf8ded3552693a433311c6a4ce6f4e12a2c
+  sha256: 2fa092705ea640d605c435b1ca82b2866a1b601cdf96f076d70b79a855eba90d
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: true  # [py<39]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
+  skip: true  # [py<310]
 
 requirements:
   host:
@@ -25,12 +25,23 @@ requirements:
     - python
 
 test:
-  requires:
-    - pip
-  commands:
-    - pip check
+  source_files:
+    - tests
   imports:
     - humanize
+    - humanize.filesize
+    - humanize.i18n
+    - humanize.lists
+    - humanize.number
+    - humanize.time
+  requires:
+    - pip
+    - pytest
+    - freezegun
+  commands:
+    - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - pytest -ra -vv --tb=short tests
 
 about:
   home: https://github.com/python-humanize/humanize
@@ -43,7 +54,7 @@ about:
     data into human-readable formats. It includes functions for formatting
     numbers, dates, and times in a way that is easy to read and understand.
   dev_url: https://github.com/python-humanize/humanize
-  doc_url: https://humanize.readthedocs.io/
+  doc_url: https://humanize.readthedocs.io
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
humanize 4.14.0 

**Destination channel:** Defaults

### Links

- [PKG-10520]
- dev_url:        https://github.com/python-humanize/humanize/tree/4.14.0
- conda_forge:    https://github.com/conda-forge/humanize-feedstock
- pypi:           https://pypi.org/project/humanize/4.14.0
- pypi inspector: https://inspector.pypi.io/project/humanize/4.14.0

### Explanation of changes:

- new version number 4.12.2 -> 4.14.0 
- updated skip py<310
- improved test imports
- added tests running


[PKG-10520]: https://anaconda.atlassian.net/browse/PKG-10520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ